### PR TITLE
update Chinese and some suggestions

### DIFF
--- a/WorldSphereMod/Locales/ch.json
+++ b/WorldSphereMod/Locales/ch.json
@@ -4,7 +4,7 @@
   //WorldSphereTab
   "world_sphere_tab": "立體世界",
   "world_sphere_tab_desc": "讓遊戲視角變為3D立體!",
-  "world_sphere_tab_author": "製作:Melvin  漢化:半梦半醒",
+  "world_sphere_tab_author": "製作:Melvin    漢化:半梦半醒",
   "is_3d": "3D世界",
   "is_3d_description": "切換此開關，然後重新加載世界\n這樣才能在平面和立體間切換",
   "sprite_settings": "貼圖設置",
@@ -29,4 +29,12 @@
   "flat_shape": "地平説",
   "flat_shape_description": "讓世界變成平面",
   "tile_length_multiplier": "方塊長度倍數",
+  "camera_rotates_with_world": "視角跟隨",
+  "camera_rotates_with_world_description": "當你控制一個單位前，開啓這個沉浸感更強",
+  "perlin_noise": "細緻落差",
+  "perlin_noise_description": "使用柏林噪聲讓世界中的高度進行更細緻的區分",
+  "upside_down_movement": "移動顛倒",
+  "upside_down_movement_description": "如果視角相比初始是顛倒的，那操作也會隨之顛倒",    
+  "open_sprites": "打開貼圖文件",
+  "open_sprites_description":  "打開包含模組資源的文件夾，可以對其進行編輯，然後重啓遊戲以生效"
 }

--- a/WorldSphereMod/Locales/cz.json
+++ b/WorldSphereMod/Locales/cz.json
@@ -4,7 +4,7 @@
   //WorldSphereTab
   "world_sphere_tab": "立体世界",
   "world_sphere_tab_desc": "让游戏视角变为3D立体!",
-  "world_sphere_tab_author": "制作:Melvin  汉化:半梦半醒",
+  "world_sphere_tab_author": "制作:Melvin    汉化:半梦半醒",
   "is_3d": "3D世界",
   "is_3d_description": "切换此开关，然后重新加载世界\n这样才能在平面和立体间切换",
   "sprite_settings": "贴图设置",
@@ -29,4 +29,12 @@
   "flat_shape": "地平说",
   "flat_shape_description": "让世界变成平面",
   "tile_length_multiplier": "方块长度倍数",
+  "camera_rotates_with_world": "视角跟随",
+  "camera_rotates_with_world_description": "当你控制一个单位前，开启这个沉浸感更强",
+  "perlin_noise": "细致落差",
+  "perlin_noise_description": "使用柏林噪声让世界中的高度进行更细致的区分",
+  "upside_down_movement": "移动颠倒",
+  "upside_down_movement_description": "如果视角相比初始是颠倒的，那操作也会随之颠倒",
+  "open_sprites": "打开贴图文件",
+  "open_sprites_description":  "打开包含模组资源的文件夹，可以对其进行编辑，然后重启游戏以生效"
 }


### PR DESCRIPTION
some suggestions, if display effect is too bad, can be rejected
`sea level`: ocean blocks height are not consistent.There should be a sea level — when view is underwater, add a little blue mask
`basic tiles line`: under Berlin random noise,ocean may be higher than sand, and similar situations occur on other tiles as well. Set ocean height to 0. Personally, I think sand height ranges 30 ~ 300, low 50 ~ 210, high 240 ~ 450, hills 500 ~ 900, mountains 1100 ~ 2100, and summits above 2200. This seems to be a more reasonable range(for example unit height 80[8px height] and buildings 260[26px])
`diagonal buildings`:place icon along the diagonal of occupied area of the buildings,to save performance